### PR TITLE
fix UnicodeDecodeError in Windows terminal

### DIFF
--- a/models/tag2text.py
+++ b/models/tag2text.py
@@ -152,7 +152,7 @@ class RAM(nn.Module):
             self.class_threshold[key] = value
 
     def load_tag_list(self, tag_list_file):
-        with open(tag_list_file, 'r') as f:
+        with open(tag_list_file, 'r', encoding="utf-8") as f:
             tag_list = f.read().splitlines()
         tag_list = np.array(tag_list)
         return tag_list


### PR DESCRIPTION
Fixes `UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 32: character maps to <undefined>` error on Windows. Probably related to chinese characters.